### PR TITLE
Basic library of matrix functions in C

### DIFF
--- a/C/matrixlib/Makefile
+++ b/C/matrixlib/Makefile
@@ -1,0 +1,11 @@
+CC= gcc -std=c99
+FLAGS= -Wall -Wextra -Wundef -Wpointer-arith -Wshadow -Wcast-align -Wstrict-prototypes -Waggregate-return
+
+main: matrix.c
+	$(CC) -o main.o main.c matrix.c
+
+matrix: matrix.c matrix.h
+	$(CC) -c matrix.c
+
+make clean: 
+	rm -rf *.o

--- a/C/matrixlib/main.c
+++ b/C/matrixlib/main.c
@@ -1,0 +1,13 @@
+#include "matrix.h"
+
+int main(void) {
+    double arr[9] = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    matrix * m;
+    m = init(arr, 3, 3);
+    printf("%d,%d\n", m->rows, m->cols);
+    print(*m);
+
+    return 0;
+    
+
+}

--- a/C/matrixlib/main.c
+++ b/C/matrixlib/main.c
@@ -1,11 +1,33 @@
 #include "matrix.h"
 
+void print_arr(double * arr, int n) {
+    for (int i = 0; i < n; i++)
+        printf("%lf,", arr[i]);
+    printf("\n");
+}
+
 int main(void) {
-    double arr[6] = { 4, 5, 6, 7, 8, 9 };
-    matrix m = init(arr, 2, 3);
-    printf("%d,%d\n", m->rows, m->cols);
+    double arr[9] = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    matrix m = init(arr, 3, 3);
     print(m);
+    printf("\n");
+    matrix n = transpose(m);
+    print(n);
+    printf("\n");
+
+    matrix asdf = mul(m, n);
+    matrix fdsa = mul(n, m);
+
+    print(asdf);
+    printf("\n");
+
+    print(fdsa);
+    printf("\n");
+
+
     del(m);
+    del(n);
+    del(asdf);
 
 
     return 0;

--- a/C/matrixlib/main.c
+++ b/C/matrixlib/main.c
@@ -1,13 +1,12 @@
 #include "matrix.h"
 
 int main(void) {
-    double arr[9] = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-    matrix * m;
-    m = init(arr, 3, 3);
+    double arr[6] = { 4, 5, 6, 7, 8, 9 };
+    matrix m = init(arr, 2, 3);
     printf("%d,%d\n", m->rows, m->cols);
-    print(*m);
+    print(m);
+    del(m);
+
 
     return 0;
-    
-
 }

--- a/C/matrixlib/matrix.c
+++ b/C/matrixlib/matrix.c
@@ -1,8 +1,12 @@
 #include "matrix.h"
 
 matrix init(double * arr, int rows, int cols) {
+    assert(rows > 0);
+    assert(cols > 0);
+
     matrix mat = malloc(sizeof(matrix));
     assert(mat != NULL);
+
     int size = rows * cols;
     mat->arr = malloc(size * sizeof(double));
     assert(mat->arr != NULL);
@@ -24,44 +28,106 @@ int del(matrix mat) {
 }
 
 void print(matrix mat) {
+    assert(mat->rows > 0);
+    assert(mat->cols > 0);
+
     for (int i = 0; i < mat->rows; i++) {
         printf("["); 
         for (int j = 0; j < mat->cols - 1; j++) {
             printf("%2.2lf,", mat->arr[i * mat->cols + j]);
         }
-        printf("%2.2lf]\n", mat->arr[i * mat->cols + mat->rows - 1]);
+        printf("%2.2lf]\n", mat->arr[i * mat->cols + mat->cols - 1]);
     }
 }
 
 matrix add(matrix mat1, matrix mat2) {
     assert(mat1->rows == mat2->rows);
     assert(mat1->cols == mat2->cols);
+
     double * arr = malloc(mat1->size * sizeof(double));
     for (int i = 0; i < mat1->size; i++)
         arr[i] = mat1->arr[i] + mat2->arr[i];
 
-    return init(arr, mat1->rows, mat1->cols);
+    matrix mat3 = init(arr, mat1->rows, mat1->cols);
+    free(arr);
+
+    return mat3;
 }
 
 matrix sub(matrix mat1, matrix mat2) {
     assert(mat1->rows == mat2->rows);
     assert(mat1->cols == mat2->cols);
+
     double * arr = malloc(mat1->size * sizeof(double));
     for (int i = 0; i < mat1->size; i++)
         arr[i] = mat1->arr[i] - mat2->arr[i];
 
-    return init(arr, mat1->rows, mat1->cols);
+    matrix mat3 = init(arr, mat1->rows, mat1->cols);
+    free(arr);
+
+    return mat3;
+}
+
+matrix mul(matrix mat1, matrix mat2) {
+    assert(mat1->cols == mat2->rows);
+
+    double * arr = malloc(mat1->rows * mat2->cols * sizeof(double));
+    int rows = mat1->rows;
+    int cols = mat2->cols;
+    int mid = mat1->cols;
+    int index;
+
+    for (int i = 0; i < rows; i++) {
+        for (int j = 0; j < cols; j++) {
+            index = i * rows + j;
+            arr[index] = 0.0;
+            for (int k = 0; k < mid; k++) {
+                arr[index] += mat1->arr[i * mat1->cols + k] * mat2->arr[k * mat2->cols + j];
+            }
+        }
+    }
+
+    matrix mat3 = init(arr, mat1->rows, mat2->cols);
+    free(arr);
+
+    return mat3;
+
 }
 
 matrix transpose(matrix mat) {
-    assert(mat->rows > 0);
-    assert(mat->cols > 0);
-
     double * arr = malloc(mat->size * sizeof(double));
     for (int i = 0; i < mat->rows; i++) {
         for (int j = 0; j < mat->cols; j++) {
             arr[j * mat->rows + i] = mat->arr[i * mat->cols + j];
         }
     }
-    return init(arr, mat->cols, mat->rows);
+    matrix mat_transpose = init(arr, mat->cols, mat->rows);
+    free(arr);
+
+    return mat_transpose;
+}
+
+matrix vectorized(double (*func)(double), matrix mat) {
+    double * arr = malloc(mat->size * sizeof(double));
+    for (int i = 0; i < mat->size; i++) {
+        arr[i] = func(mat->arr[i]);
+    }
+
+    matrix new_mat = init(arr, mat->rows, mat->cols);
+    free(arr);
+
+    return new_mat;
+}
+
+matrix scale(matrix mat, double scalar) {
+    double * arr = malloc(mat->size * sizeof(double));
+    for (int i = 0; i < mat->size; i++) {
+        arr[i] = scalar * mat->arr[i];
+    }
+
+    matrix new_mat = init(arr, mat->rows, mat->cols);
+    free(arr);
+
+    return new_mat;
+
 }

--- a/C/matrixlib/matrix.c
+++ b/C/matrixlib/matrix.c
@@ -1,31 +1,67 @@
 #include "matrix.h"
 
-matrix * init(double * arr, int rows, int cols) {
-    matrix * mat = malloc(sizeof(matrix));
-    if (mat != NULL) {
-        mat->arr = malloc(rows * cols * sizeof(double));
-        if (mat->arr != NULL) {
-            memcpy(mat->arr, arr, rows * cols);
-            mat->rows = rows;
-            mat->cols = cols;
-        }
-    }
+matrix init(double * arr, int rows, int cols) {
+    matrix mat = malloc(sizeof(matrix));
+    assert(mat != NULL);
+    int size = rows * cols;
+    mat->arr = malloc(size * sizeof(double));
+    assert(mat->arr != NULL);
+
+    for(int i = 0; i < size; i++) 
+        mat->arr[i] = arr[i];
+
+    mat->rows = rows;
+    mat->cols = cols;
+    mat->size = size;
+
     return mat;
 }
 
-int del(matrix * mat) {
+int del(matrix mat) {
     free(mat->arr);
-    //free(mat);
+    free(mat);
     return EXIT_SUCCESS;
 }
 
 void print(matrix mat) {
-    for (int i = 0; i < mat.rows; i++) {
-       printf("["); 
-        for (int j = 0; j < mat.cols - 1; j++) {
-            printf("%2.2lf,", mat.arr[i * mat.cols + j]);
+    for (int i = 0; i < mat->rows; i++) {
+        printf("["); 
+        for (int j = 0; j < mat->cols - 1; j++) {
+            printf("%2.2lf,", mat->arr[i * mat->cols + j]);
         }
-        printf("%2.2lf]\n", mat.arr[i * mat.cols + mat.rows - 1]);
+        printf("%2.2lf]\n", mat->arr[i * mat->cols + mat->rows - 1]);
     }
+}
 
+matrix add(matrix mat1, matrix mat2) {
+    assert(mat1->rows == mat2->rows);
+    assert(mat1->cols == mat2->cols);
+    double * arr = malloc(mat1->rows * mat1->cols * sizeof(double));
+    for (int i = 0; i < mat1->rows * mat1->cols; i++)
+        arr[i] = mat1->arr[i] + mat2->arr[i];
+
+    return init(arr, mat1->rows, mat1->cols);
+}
+
+matrix sub(matrix mat1, matrix mat2) {
+    assert(mat1->rows == mat2->rows);
+    assert(mat1->cols == mat2->cols);
+    double * arr = malloc(mat1->rows * mat1->cols * sizeof(double));
+    for (int i = 0; i < mat1->rows * mat1->cols; i++)
+        arr[i] = mat1->arr[i] - mat2->arr[i];
+
+    return init(arr, mat1->rows, mat1->cols);
+}
+
+matrix transpose(matrix mat) {
+    assert(mat->rows > 0);
+    assert(mat->cols > 0);
+
+    double * arr = malloc(mat->rows * mat->cols * sizeof(double));
+    for (int i = 0; i < mat->rows; i++) {
+        for (int j = 0; j < mat->cols; j++) {
+            arr[j * mat->rows + i] = mat->arr[i * mat->cols + j];
+        }
+    }
+    return init(arr, mat->cols, mat->rows);
 }

--- a/C/matrixlib/matrix.c
+++ b/C/matrixlib/matrix.c
@@ -36,8 +36,8 @@ void print(matrix mat) {
 matrix add(matrix mat1, matrix mat2) {
     assert(mat1->rows == mat2->rows);
     assert(mat1->cols == mat2->cols);
-    double * arr = malloc(mat1->rows * mat1->cols * sizeof(double));
-    for (int i = 0; i < mat1->rows * mat1->cols; i++)
+    double * arr = malloc(mat1->size * sizeof(double));
+    for (int i = 0; i < mat1->size; i++)
         arr[i] = mat1->arr[i] + mat2->arr[i];
 
     return init(arr, mat1->rows, mat1->cols);
@@ -46,8 +46,8 @@ matrix add(matrix mat1, matrix mat2) {
 matrix sub(matrix mat1, matrix mat2) {
     assert(mat1->rows == mat2->rows);
     assert(mat1->cols == mat2->cols);
-    double * arr = malloc(mat1->rows * mat1->cols * sizeof(double));
-    for (int i = 0; i < mat1->rows * mat1->cols; i++)
+    double * arr = malloc(mat1->size * sizeof(double));
+    for (int i = 0; i < mat1->size; i++)
         arr[i] = mat1->arr[i] - mat2->arr[i];
 
     return init(arr, mat1->rows, mat1->cols);
@@ -57,7 +57,7 @@ matrix transpose(matrix mat) {
     assert(mat->rows > 0);
     assert(mat->cols > 0);
 
-    double * arr = malloc(mat->rows * mat->cols * sizeof(double));
+    double * arr = malloc(mat->size * sizeof(double));
     for (int i = 0; i < mat->rows; i++) {
         for (int j = 0; j < mat->cols; j++) {
             arr[j * mat->rows + i] = mat->arr[i * mat->cols + j];

--- a/C/matrixlib/matrix.c
+++ b/C/matrixlib/matrix.c
@@ -1,0 +1,31 @@
+#include "matrix.h"
+
+matrix * init(double * arr, int rows, int cols) {
+    matrix * mat = malloc(sizeof(matrix));
+    if (mat != NULL) {
+        mat->arr = malloc(rows * cols * sizeof(double));
+        if (mat->arr != NULL) {
+            memcpy(mat->arr, arr, rows * cols);
+            mat->rows = rows;
+            mat->cols = cols;
+        }
+    }
+    return mat;
+}
+
+int del(matrix * mat) {
+    free(mat->arr);
+    //free(mat);
+    return EXIT_SUCCESS;
+}
+
+void print(matrix mat) {
+    for (int i = 0; i < mat.rows; i++) {
+       printf("["); 
+        for (int j = 0; j < mat.cols - 1; j++) {
+            printf("%2.2lf,", mat.arr[i * mat.cols + j]);
+        }
+        printf("%2.2lf]\n", mat.arr[i * mat.cols + mat.rows - 1]);
+    }
+
+}

--- a/C/matrixlib/matrix.h
+++ b/C/matrixlib/matrix.h
@@ -62,7 +62,7 @@ typedef struct matrix_t * matrix;
  */
 matrix init(double * arr, int rows, int cols);
 
-/*
+/* WARNING: UNIMPLEMENTED
  * Procedure:
  *   del
  * Purpose:
@@ -206,15 +206,34 @@ double det(matrix mat);
  *   func, a unary function pointer
  *   mat, a matrix
  * Produces:
- *   vmat, a matrix
+ *   new_mat, a matrix
  * Preconditions:
  *   mat is an initialized matrix
  *   func is actually pointing to a valid function
  * Postconditions:
- *   vmat->arr[i] == f(mat->arr[i]) for all i
- *   vmat->rows == mat->rows
- *   vmat->cols == mat->cols
+ *   new_mat->arr[i] == f(mat->arr[i]) for all i
+ *   new_mat->rows == mat->rows
+ *   new_mat->cols == mat->cols
  */
 matrix vectorized(double (*func)(double), matrix mat);
+
+/*
+ * Procedure:
+ *   scale
+ * Purpose:
+ *   applies a scalar to each entry of a matrix
+ * Parameters:
+ *   mat, a matrix
+ *   scalar, a double
+ * Produces:
+ *   new_mat, a matrix
+ * Preconditions:
+ *   mat is an initialized matrix
+ * Postconditions:
+ *   new_mat->arr[i] == scalar * mat->arr[i] for all i
+ *   new_mat->rows == mat->rows
+ *   new_mat->cols == mat->cols
+ */
+matrix scale(matrix mat, double scalar);
 
 #endif

--- a/C/matrixlib/matrix.h
+++ b/C/matrixlib/matrix.h
@@ -9,8 +9,9 @@
 
 /*
  * The matrix_t struct. This includes a double array pointer which serves as the
- * underlying machine representation of the matrix. The two integers indicate
- * the shape of the matrix.
+ * underlying machine representation of the matrix. The two integers rows and
+ * cols indicate the shape of the matrix. For convenience, size is just the
+ * product of rows and cols.
  */
 struct matrix_t {
     double * arr;
@@ -24,17 +25,196 @@ struct matrix_t {
  */
 typedef struct matrix_t * matrix;
 
+/*
+ * Procedure:
+ *   init
+ * Purpose:
+ *   this procedure takes a primitive array of doubles and shape parameters and
+ *   returns a pointer to a matrix_t which stores the array and the shape inside
+ *   the struct.
+ * Parameters:
+ *   arr, an array of type double
+ *   rows, an int
+ *   cols, an int
+ * Produces:
+ *   mat, a matrix
+ * Preconditions:
+ *   rows > 0 (this is checked)
+ *   cols > 0 (this is checked)
+ *   the length of arr must equal rows * cols (this is NOT checked)
+ * Postconditions:
+ *   if all preconditions are met, and malloc succeeds in initializing a matrix
+ *   and a new array, then we have
+ *     mat->arr[i] = arr[i] for all i (mat->arr is a copy of arr)
+ *     mat->rows = rows
+ *     mat->cols = cols
+ *     mat->size = rows * cols
+ * Notes:
+ *   this procedure fails if:
+ *     rows <= 0
+ *     cols <= 0
+ *     malloc fails to allocate space for a matrix_t
+ *     malloc fails to allocate space for an array of size rows*cols
+ *   this procedure has undefined behavior if:
+ *     length of arr != rows * cols
+ *   in a perfect world, you should avoid calling init and build matrices using
+ *   other built-ins
+ */
 matrix init(double * arr, int rows, int cols);
+
+/*
+ * Procedure:
+ *   del
+ * Purpose:
+ *   this procedure takes an initialized matrix and frees the memory
+ * Parameters:
+ *   mat, a matrix
+ * Produces:
+ *   success, an int
+ * Preconditions:
+ *   mat must be previously initialized (this is not checked)
+ * Postconditions:
+ *   mat no longer is associated with any data, and the previous data in mat has
+ *   been freed
+ *   if deletion is successful, success is EXIT_SUCCESS
+ * Notes:
+ *   for every malloc, you need a free. the model in this library is simplified
+ *   so that for every matrix, you simply need an init call and a del call. this
+ *   ensures that there are no leaks.
+ */
 int del(matrix mat);
 
+/*
+ * Procedure:
+ *   print
+ * Purpose:
+ *   prints a string representation of a matrix into stdout
+ * Parameters:
+ *   mat, a matrix
+ * Produces:
+ *   [Called for side effects]
+ * Preconditions:
+ *   mat must be initialized
+ * Postconditions:
+ *   the string displayed is formatted according to the shape information in mat
+ */
 void print(matrix mat);
 
+/* 
+ * Procedure:
+ *   add
+ * Purpose:
+ *   adds two matrices
+ * Parameters:
+ *   mat1, a matrix
+ *   mat2, a matrix
+ * Produces:
+ *   mat3, a matrix
+ * Preconditions:
+ *   mat1 and mat2 are initialized matrices
+ *   mat1->rows == mat2->rows (this is checked)
+ *   mat1->cols == mat2->cols (this is checked)
+ * Postconditions:
+ *   mat3->arr[i] == mat1->arr[i] + mat2->arr[i] for all i
+ *   mat3->rows == mat1->rows == mat2->rows
+ *   mat3->cols == mat1->cols == mat2->cols
+ */
 matrix add(matrix mat1, matrix mat2);
-matrix sub(matrix mat1, matrix mat2);
 
+/* 
+ * Procedure:
+ *   sub
+ * Purpose:
+ *   subtracts two matrices
+ * Parameters:
+ *   mat1, a matrix
+ *   mat2, a matrix
+ * Produces:
+ *   mat3, a matrix
+ * Preconditions:
+ *   mat1 and mat2 are initialized matrices
+ *   mat1->rows == mat2->rows (this is checked)
+ *   mat1->cols == mat2->cols (this is checked)
+ * Postconditions:
+ *   mat3->arr[i] == mat1->arr[i] - mat2->arr[i] for all i
+ *   mat3->rows == mat1->rows == mat2->rows
+ *   mat3->cols == mat1->cols == mat2->cols
+ */
+ matrix sub(matrix mat1, matrix mat2);
+
+/* 
+ * Procedure:
+ *   mul 
+ * Purpose:
+ *   multiplies two matrices
+ * Parameters:
+ *   mat1, a matrix
+ *   mat2, a matrix
+ * Produces:
+ *   mat3, a matrix
+ * Preconditions:
+ *   mat1 and mat2 are initialized matrices
+ *   mat1->cols == mat2->rows (this is checked)
+ * Postconditions:
+ *   mat3->rows == mat1->rows
+ *   mat3->cols == mat2->cols
+ *   mat3->arr is the result of the matrix product of mat1 and mat2
+ */
 matrix mul(matrix mat1, matrix mat2);
+
+/* 
+ * Procedure:
+ *   transpose
+ * Purpose:
+ *   transposes a matrix
+ * Parameters:
+ *   mat, a matrix
+ * Produces:
+ *   mat_transpose, a matrix
+ * Preconditions:
+ *   mat is an initialized matrix
+ * Postconditions:
+ *   the "ij"th entry of mat_transpose corresponds to the "ji"th entry of mat
+ *   mat_transpose->rows = mat->cols
+ *   mat_transpose->cols = mat->rows
+ */
 matrix transpose(matrix mat);
+
+/*
+ * Procedure:
+ *   det
+ * Purpose:
+ *   computes the determinant of a matrix
+ * Parameters:
+ *   mat, a matrix
+ * Produces:
+ *   det, a double
+ * Preconditions:
+ *   mat is an initialized matrix
+ * Postconditions:
+ *   det has all sorts of properties that are hard to verify in C. The Wikipedia
+ *   entry is useful.
+ */
 double det(matrix mat);
 
+/*
+ * Procedure:
+ *   vectorized
+ * Purpose:
+ *   applies a unary function to each entry of a matrix
+ * Parameters:
+ *   func, a unary function pointer
+ *   mat, a matrix
+ * Produces:
+ *   vmat, a matrix
+ * Preconditions:
+ *   mat is an initialized matrix
+ *   func is actually pointing to a valid function
+ * Postconditions:
+ *   vmat->arr[i] == f(mat->arr[i]) for all i
+ *   vmat->rows == mat->rows
+ *   vmat->cols == mat->cols
+ */
+matrix vectorized(double (*func)(double), matrix mat);
 
 #endif

--- a/C/matrixlib/matrix.h
+++ b/C/matrixlib/matrix.h
@@ -5,15 +5,27 @@
 #include <stdio.h>
 #include <math.h>
 #include <string.h>
+#include <assert.h>
 
-typedef struct matrix_t {
+/*
+ * The matrix_t struct. This includes a double array pointer which serves as the
+ * underlying machine representation of the matrix. The two integers indicate
+ * the shape of the matrix.
+ */
+struct matrix_t {
     double * arr;
     int rows;
     int cols;
-} matrix;
+    int size;
+};
 
-matrix * init(double * arr, int rows, int cols);
-int del(matrix * mat);
+/*
+ * So you don't have to shove a whole matrix through a function call...
+ */
+typedef struct matrix_t * matrix;
+
+matrix init(double * arr, int rows, int cols);
+int del(matrix mat);
 
 void print(matrix mat);
 

--- a/C/matrixlib/matrix.h
+++ b/C/matrixlib/matrix.h
@@ -1,0 +1,28 @@
+#ifndef MATRIXLIB_H
+#define MATRIXLIB_H
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+
+typedef struct matrix_t {
+    double * arr;
+    int rows;
+    int cols;
+} matrix;
+
+matrix * init(double * arr, int rows, int cols);
+int del(matrix * mat);
+
+void print(matrix mat);
+
+matrix add(matrix mat1, matrix mat2);
+matrix sub(matrix mat1, matrix mat2);
+
+matrix mul(matrix mat1, matrix mat2);
+matrix transpose(matrix mat);
+double det(matrix mat);
+
+
+#endif


### PR DESCRIPTION
This directory implements a basic library of matrix functions in C. Documentation can be found in `matrix.h`.

# Data model
The matrix type that a user will interact with is a pointer to the following struct:

```C
struct matrix_t {
  double * arr;
  int rows;
  int cols;
  int size;
}
```

Memory initialization and deletion are taken care of by library functions. A user should never have to call `malloc` or `free` when using this library. All functions *return* matrices, not overwrite existing matrices. This means that if you want to ensure no memory leaks, you need to initialize a matrix for every function call that is made, and then delete it at the end. Assume you have a matrix `mat` with the data
```
[1, 2, 3]
[4, 5, 6]
[7, 8, 9]
```
then basic usage is given by
```C
matrix new_mat = transpose(mat);
matrix sym_mat = mul(mat, new_mat); // this will be square symmetric

print(sym_mat);

// Free the matrices at the end
del(sym_mat);
del(new_mat);
del(mat);
```
In main, this gives output of 
```
[14.00,32.00,50.00]
[32.00,77.00,122.00]
[50.00,122.00,194.00]
```
and valgrind reports no memory leaks.

# Functions
The currently implemented functions are:

* addition
* subtract
* multiplication
* transpose
* scalar multiplication
* unary function application

The following functions are implemented for memory purposes:

* init
* del

The following functions are currently unimplemented:

* matrix determinant

The following miscellaneous functions are implemented:

* matrix print



