### PR TITLE
maximum field form - haskell

### DIFF
--- a/Haskell/MaximumFieldForm.hs
+++ b/Haskell/MaximumFieldForm.hs
@@ -1,0 +1,45 @@
+#!/usr/bin/env runhaskell
+
+import Control.Monad (when, unless)
+import System.IO
+import Text.Printf
+
+main :: IO ()
+main = do
+  putStr "a: "
+  hFlush stdout
+  a <- fmap read getLine :: IO Double
+  putStr "\n"
+  putStr "b: "
+  hFlush stdout
+  b <- fmap read getLine :: IO Double
+  putStr $ concat
+    [ "\n"
+    , "i", spaces
+    , "a", spaces
+    , "b", spaces
+    , "c", spaces
+    , "f(a)", replicate 7 ' '
+    , "f(c)", replicate 7 ' '
+    , "|c|", replicate 7 ' '
+    , "\n\n"
+    ]
+  mff f a b 0
+
+spaces = replicate 10 ' '
+eps = 1e-6
+
+f :: Double -> Double
+f x = (pi - (2 * x)) * sin x * cos x - (sin x ^^ 2)
+
+mff :: (Double -> Double) -> Double -> Double -> Double -> IO ()
+mff g a b i = when (abs (b - a) > eps) $ do
+  let c = (a + b) / 2
+      ga = g a
+      gc = g c
+  printf "%.0f     %.3f      %.3f       %.3f       %.3f       %.3f       %.3f\n" (i + 1) a b c ga gc (abs c)
+  let (a',b') = if ga * gc < 0
+        then (a,c)
+        else (c,b)
+  unless (abs (b' - a') < eps) $ do
+    mff g a' b' (i + 1)


### PR DESCRIPTION
to somewhat verify correctness, i compared the haskell output to the python output. barring rounding due to printf formatting, they are the same.

python:

```
[nix-shell:~/development/Numerical-Analysis-Examples/Python]$ python maximumfieldform.py
('i', 'a', 'b', 'c', 'f(a)', 'f(c)', '|c|')
(1, 0, 1, 0.5, 0.0, 0.6711951925708497, 0.5)
(2, 0.5, 1, 0.75, 0.6711951925708497, 0.35410882183478387, 0.75)
(3, 0.75, 1, 0.875, 0.35410882183478387, 0.09553077962793732, 0.875)
(4, 0.875, 1, 0.9375, 0.09553077962793732, -0.045547732154130105, 0.9375)
(5, 0.875, 0.9375, 0.90625, 0.09553077962793732, 0.025550465314734816, 0.90625)
(6, 0.90625, 0.9375, 0.921875, 0.025550465314734816, -0.009890949773533553, 0.921875)
(7, 0.90625, 0.921875, 0.9140625, 0.025550465314734816, 0.007860685824143676, 0.9140625)
(8, 0.9140625, 0.921875, 0.91796875, 0.007860685824143676, -0.0010079009347784273, 0.91796875)
(9, 0.9140625, 0.91796875, 0.916015625, 0.007860685824143676, 0.0034282628251341984, 0.916015625)
(10, 0.916015625, 0.91796875, 0.9169921875, 0.0034282628251341984, 0.0012106407125360708, 0.9169921875)
(11, 0.9169921875, 0.91796875, 0.91748046875, 0.0012106407125360708, 0.00010148385226182999, 0.91748046875)
(12, 0.91748046875, 0.91796875, 0.917724609375, 0.00010148385226182999, -0.00045318017271867017, 0.917724609375)
(13, 0.91748046875, 0.917724609375, 0.9176025390625, 0.00010148385226182999, -0.00017584105280521456, 0.9176025390625)
(14, 0.91748046875, 0.9176025390625, 0.91754150390625, 0.00010148385226182999, -3.717682150494728e-05, 0.91754150390625)
(15, 0.91748046875, 0.91754150390625, 0.917510986328125, 0.00010148385226182999, 3.215396030920026e-05, 0.917510986328125)
(16, 0.917510986328125, 0.91754150390625, 0.9175262451171875, 3.215396030920026e-05, -2.5113193951042945e-06, 0.9175262451171875)
(17, 0.917510986328125, 0.9175262451171875, 0.9175186157226562, 3.215396030920026e-05, 1.482134826147341e-05, 0.9175186157226562)
(18, 0.9175186157226562, 0.9175262451171875, 0.9175224304199219, 1.482134826147341e-05, 6.155021383791315e-06, 0.9175224304199219)
(19, 0.9175224304199219, 0.9175262451171875, 0.9175243377685547, 6.155021383791315e-06, 1.8218527320090772e-06, 0.9175243377685547)
(20, 0.9175243377685547, 0.9175262451171875, 0.9175252914428711, 1.8218527320090772e-06, -3.447328971173391e-07, 0.9175252914428711)
```

haskell:

```
a: 0

b: 1

i          a          b          c          f(a)       f(c)       |c|

1     0.000      1.000       0.500       0.000       0.671       0.500
2     0.500      1.000       0.750       0.671       0.354       0.750
3     0.750      1.000       0.875       0.354       0.096       0.875
4     0.875      1.000       0.938       0.096       -0.046       0.938
5     0.875      0.938       0.906       0.096       0.026       0.906
6     0.906      0.938       0.922       0.026       -0.010       0.922
7     0.906      0.922       0.914       0.026       0.008       0.914
8     0.914      0.922       0.918       0.008       -0.001       0.918
9     0.914      0.918       0.916       0.008       0.003       0.916
10     0.916      0.918       0.917       0.003       0.001       0.917
11     0.917      0.918       0.917       0.001       0.000       0.917
12     0.917      0.918       0.918       0.000       -0.000       0.918
13     0.917      0.918       0.918       0.000       -0.000       0.918
14     0.917      0.918       0.918       0.000       -0.000       0.918
15     0.917      0.918       0.918       0.000       0.000       0.918
16     0.918      0.918       0.918       0.000       -0.000       0.918
17     0.918      0.918       0.918       0.000       0.000       0.918
18     0.918      0.918       0.918       0.000       0.000       0.918
19     0.918      0.918       0.918       0.000       0.000       0.918
20     0.918      0.918       0.918       0.000       -0.000       0.918
```